### PR TITLE
Add group operations

### DIFF
--- a/src/main/java/org/metropolia/minimalnotepad/controller/GroupController.java
+++ b/src/main/java/org/metropolia/minimalnotepad/controller/GroupController.java
@@ -1,8 +1,15 @@
 package org.metropolia.minimalnotepad.controller;
 
+import org.metropolia.minimalnotepad.dto.ErrorResponse;
 import org.metropolia.minimalnotepad.model.Group;
+import org.metropolia.minimalnotepad.model.User;
+import org.metropolia.minimalnotepad.model.UserGroupParticipation;
 import org.metropolia.minimalnotepad.service.GroupService;
 
+import org.metropolia.minimalnotepad.service.UserGroupParticipationService;
+import org.metropolia.minimalnotepad.service.UserService;
+import org.metropolia.minimalnotepad.utils.JwtUtils;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,11 +19,16 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/groups")
 public class GroupController {
-
+    private final UserService userService;
     private final GroupService groupService;
+    private final JwtUtils jwtUtils;
+    private final UserGroupParticipationService userGroupParticipationService;
 
-    public GroupController(GroupService groupService) {
+    public GroupController(UserService userService, GroupService groupService, JwtUtils jwtUtils, UserGroupParticipationService userGroupParticipationService) {
+        this.userService = userService;
         this.groupService = groupService;
+        this.jwtUtils = jwtUtils;
+        this.userGroupParticipationService = userGroupParticipationService;
     }
 
     @GetMapping
@@ -30,7 +42,16 @@ public class GroupController {
     }
 
     @PostMapping
-    public ResponseEntity<Group> createGroup(@RequestBody Group group) {
+    public ResponseEntity<?> createGroup(@RequestHeader("Authorization") String authorizationHeader, @RequestBody Group group) {
+        String token = jwtUtils.getTokenFromHeader(authorizationHeader);
+        User user = userService.getUserFromToken(token);
+
+        // Check if the group name is unique
+        if (groupService.isGroupNameTaken(group.getName())) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponse(400, "Group name is already taken"));
+        }
+
+        group.setUser(user);
         Group createdGroup = groupService.createGroup(group);
         return ResponseEntity
                 .created(URI.create("/api/groups/" + createdGroup.getId()))
@@ -45,6 +66,42 @@ public class GroupController {
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteGroup(@PathVariable Long id) {
         groupService.deleteGroup(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/user")
+    public ResponseEntity<?> getGroupsByUserId(@RequestHeader("Authorization") String authorizationHeader) {
+        String token = jwtUtils.getTokenFromHeader(authorizationHeader);
+        User user = userService.getUserFromToken(token);
+
+        List<Group> groups = groupService.getGroupsByUserId(user.getId());
+
+        if (groups.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(groups);
+        }
+
+        return ResponseEntity.ok(groups);
+    }
+
+    // User joins a group
+    @PostMapping("/{groupId}/join")
+    public ResponseEntity<?> joinGroup(@RequestHeader("Authorization") String authorizationHeader,
+                                       @PathVariable Long groupId) {
+        String token = jwtUtils.getTokenFromHeader(authorizationHeader);
+        User user = userService.getUserFromToken(token);
+
+        UserGroupParticipation membership = userGroupParticipationService.joinGroup(user.getId(), groupId);
+        return ResponseEntity.ok(membership);
+    }
+
+    // User leaves a group
+    @DeleteMapping("/{groupId}/leave")
+    public ResponseEntity<?> leaveGroup(@RequestHeader("Authorization") String authorizationHeader,
+                                        @PathVariable Long groupId) {
+        String token = jwtUtils.getTokenFromHeader(authorizationHeader);
+        User user = userService.getUserFromToken(token);
+
+        userGroupParticipationService.leaveGroup(user.getId(), groupId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/metropolia/minimalnotepad/model/Group.java
+++ b/src/main/java/org/metropolia/minimalnotepad/model/Group.java
@@ -1,5 +1,6 @@
 package org.metropolia.minimalnotepad.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 
@@ -13,6 +14,10 @@ import java.util.List;
         private long id;
         private String name;
         private String description;
+        @ManyToOne
+        @JoinColumn(name = "user_id", nullable = false)
+        @JsonIgnoreProperties({"email", "notes", "password", "groupParticipationsList", "enabled", "authorities", "accountNonExpired", "accountNonLocked", "credentialsNonExpired"})
+        private User user;
         @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
         @JsonManagedReference("group-reference")
         private List<Note> notes;
@@ -37,6 +42,12 @@ import java.util.List;
     }
     public void setDescription(String description) {
         this.description = description;
+    }
+    public User getUser() {
+        return user;
+    }
+    public void setUser(User user) {
+        this.user = user;
     }
     public List<Note> getNotes(){
         return notes;

--- a/src/main/java/org/metropolia/minimalnotepad/model/User.java
+++ b/src/main/java/org/metropolia/minimalnotepad/model/User.java
@@ -27,6 +27,9 @@ public class User implements UserDetails {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JsonManagedReference("participation-user")
     private List<UserGroupParticipation> groupParticipationsList;
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JsonIgnoreProperties({"groups"})
+    private List<Group> groups;
 
     public long getId() {
         return id;

--- a/src/main/java/org/metropolia/minimalnotepad/model/UserGroupParticipation.java
+++ b/src/main/java/org/metropolia/minimalnotepad/model/UserGroupParticipation.java
@@ -18,21 +18,18 @@ public class UserGroupParticipation {
     @JoinColumn(name = "group_id")
     @JsonBackReference("participation-group")
     public Group group;
-    public boolean is_owner;
+
     public UserGroupParticipation() {
 
     }
+
+    public UserGroupId getId() { return id; }
+    public void setId(UserGroupId id) { this.id = id; }
     public void setUser(User user) {
         this.user = user;
     }
     public void setGroup(Group group) {
         this.group = group;
-    }
-    public boolean is_owner() {
-        return is_owner;
-    }
-    public void set_owner(boolean owner) {
-        is_owner = owner;
     }
     public User getUser() {
         return user;

--- a/src/main/java/org/metropolia/minimalnotepad/repository/GroupRepository.java
+++ b/src/main/java/org/metropolia/minimalnotepad/repository/GroupRepository.java
@@ -3,5 +3,9 @@ package org.metropolia.minimalnotepad.repository;
 import org.metropolia.minimalnotepad.model.Group;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface GroupRepository extends JpaRepository<Group, Long> {
+    List<Group> getGroupsByUserId(long userId);
+    boolean existsByName(String name);
 }

--- a/src/main/java/org/metropolia/minimalnotepad/repository/UserGroupParticipationRepository.java
+++ b/src/main/java/org/metropolia/minimalnotepad/repository/UserGroupParticipationRepository.java
@@ -1,0 +1,12 @@
+package org.metropolia.minimalnotepad.repository;
+
+import org.metropolia.minimalnotepad.model.Group;
+import org.metropolia.minimalnotepad.model.User;
+import org.metropolia.minimalnotepad.model.UserGroupParticipation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserGroupParticipationRepository extends JpaRepository<UserGroupParticipation, Long> {
+    Optional<UserGroupParticipation> findByUserAndGroup(User user, Group group);
+}

--- a/src/main/java/org/metropolia/minimalnotepad/service/GroupService.java
+++ b/src/main/java/org/metropolia/minimalnotepad/service/GroupService.java
@@ -37,4 +37,12 @@ public class GroupService {
     public void deleteGroup(Long id) {
         groupRepository.deleteById(id);
     }
+
+    public List<Group> getGroupsByUserId(long userId) {
+        return groupRepository.getGroupsByUserId(userId);
+    }
+
+    public boolean isGroupNameTaken(String name) {
+        return groupRepository.existsByName(name);
+    }
 }

--- a/src/main/java/org/metropolia/minimalnotepad/service/UserGroupParticipationService.java
+++ b/src/main/java/org/metropolia/minimalnotepad/service/UserGroupParticipationService.java
@@ -1,0 +1,61 @@
+package org.metropolia.minimalnotepad.service;
+
+import org.metropolia.minimalnotepad.model.Group;
+import org.metropolia.minimalnotepad.model.User;
+import org.metropolia.minimalnotepad.model.UserGroupId;
+import org.metropolia.minimalnotepad.model.UserGroupParticipation;
+import org.metropolia.minimalnotepad.repository.GroupRepository;
+import org.metropolia.minimalnotepad.repository.UserGroupParticipationRepository;
+import org.metropolia.minimalnotepad.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserGroupParticipationService {
+
+    private final UserGroupParticipationRepository userGroupParticipationRepository;
+    private final GroupRepository groupRepository;
+    private final UserRepository userRepository;
+
+    public UserGroupParticipationService(UserGroupParticipationRepository userGroupParticipationRepository,
+                                         GroupRepository groupRepository,
+                                         UserRepository userRepository) {
+        this.userGroupParticipationRepository = userGroupParticipationRepository;
+        this.groupRepository = groupRepository;
+        this.userRepository = userRepository;
+    }
+
+    // Join a group
+    public UserGroupParticipation joinGroup(Long userId, Long groupId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new RuntimeException("Group not found"));
+
+        // Check if user is already a member
+        if (userGroupParticipationRepository.findByUserAndGroup(user, group).isPresent()) {
+            throw new RuntimeException("User is already a member of this group.");
+        }
+
+        UserGroupId id = new UserGroupId(user.getId(), group.getId());
+        UserGroupParticipation participation = new UserGroupParticipation();
+        participation.setId(id);
+        participation.setUser(user);
+        participation.setGroup(group);
+        return userGroupParticipationRepository.save(participation);
+    }
+
+    // Leave a group
+    public void leaveGroup(Long userId, Long groupId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new RuntimeException("Group not found"));
+
+        UserGroupParticipation membership = userGroupParticipationRepository.findByUserAndGroup(user, group)
+                .orElseThrow(() -> new RuntimeException("User is not a member of this group."));
+
+        userGroupParticipationRepository.delete(membership);
+    }
+}

--- a/src/main/java/org/metropolia/minimalnotepad/service/UserService.java
+++ b/src/main/java/org/metropolia/minimalnotepad/service/UserService.java
@@ -5,6 +5,7 @@ import org.metropolia.minimalnotepad.model.User;
 import org.metropolia.minimalnotepad.repository.UserRepository;
 import org.metropolia.minimalnotepad.exception.UserNotFoundException;
 
+import org.metropolia.minimalnotepad.utils.JwtUtils;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -14,10 +15,12 @@ import java.util.Optional;
 public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtUtils jwtUtils;
 
-    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder, JwtUtils jwtUtils) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
+        this.jwtUtils = jwtUtils;
     }
     public User registerUser(String username, String email, String password) {
         if(userRepository.findUserByEmail(email) != null)
@@ -84,5 +87,10 @@ public class UserService {
         }
 
         userRepository.deleteById(userId);
+    }
+
+    public User getUserFromToken(String token) {
+        String username = jwtUtils.extractUsername(token);
+        return this.getUserByUsername(username);
     }
 }

--- a/src/main/java/org/metropolia/minimalnotepad/utils/JwtUtils.java
+++ b/src/main/java/org/metropolia/minimalnotepad/utils/JwtUtils.java
@@ -16,7 +16,6 @@ public class JwtUtils {
     private final int timeValidity = 1000 * 60 * 60 * 24;
     @Value("${myapp.secret-key}")
     private String secretKey;
-    
 
     public String generateToken(String username) {
         System.out.println(secretKey);
@@ -57,4 +56,10 @@ public class JwtUtils {
         return (userDetails.getUsername().equals(extractUsername(token)) && !isTokenExpired(token));
     }
 
+    public String getTokenFromHeader(String authorizationHeader) {
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            throw new IllegalArgumentException("Authorization header is invalid");
+        }
+        return authorizationHeader.substring(7);
+    }
 }

--- a/src/main/resources/POSTMAN/Minimal Notepad.postman_collection.json
+++ b/src/main/resources/POSTMAN/Minimal Notepad.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "6f8c4648-d357-4353-a1f9-f857aa76e96d",
+		"_postman_id": "93ebf417-c166-4a79-beff-dd350cf60844",
 		"name": "Minimal Notepad",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "37897491"
+		"_exporter_id": "29851757"
 	},
 	"item": [
 		{
@@ -422,17 +422,76 @@
 							}
 						},
 						"url": {
-							"raw": "{{host}}/api/groups/3",
+							"raw": "{{host}}/api/groups/4",
 							"host": [
 								"{{host}}"
 							],
 							"path": [
 								"api",
 								"groups",
-								"3"
+								"4"
 							]
 						},
 						"description": "This is a DELETE request, and it is used to delete data that was previously created via a POST request. You typically identify the entity being updated by including an identifier in the URL (eg. `id=1`).\n\nA successful DELETE request typically returns a `200 OK`, `202 Accepted`, or `204 No Content` response code."
+					},
+					"response": []
+				},
+				{
+					"name": "Get groups by User ID",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/api/groups/user",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"groups",
+								"user"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Join group",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/api/groups/8/join",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"groups",
+								"8",
+								"join"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Leave group",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{host}}/api/groups/2/leave",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"groups",
+								"2",
+								"leave"
+							]
+						}
 					},
 					"response": []
 				}
@@ -636,7 +695,7 @@
 		"bearer": [
 			{
 				"key": "token",
-				"value": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJGYWtlQWNjb3VudCIsImlhdCI6MTczOTcwNzg3NywiZXhwIjoxNzM5Nzk0Mjc3fQ.NpU5t61upGyrrsDan8R4u5E-iYP1SAUmKjdCGP5rEu0",
+				"value": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzamFja2VzMCIsImlhdCI6MTc0MDA3MTkxMSwiZXhwIjoxNzQwMTU4MzExfQ.L3msZDb2FhKUnBOMyksWPv31lvfhd7eKnGaj0-PoXGU",
 				"type": "string"
 			}
 		]

--- a/src/main/resources/create_db.sql
+++ b/src/main/resources/create_db.sql
@@ -12,14 +12,15 @@ CREATE TABLE users (
 
 CREATE TABLE groups (
                         id INT AUTO_INCREMENT PRIMARY KEY,
-                        name VARCHAR(50) NOT NULL,
-                        description VARCHAR(255)
+                        name VARCHAR(50) NOT NULL UNIQUE,
+                        description VARCHAR(255),
+                        user_id INT NOT NULL,
+                        FOREIGN KEY (user_id) REFERENCES users(id)
 );
 
 CREATE TABLE user_groups (
                              user_id INT,
                              group_id INT,
-                             is_owner BOOLEAN,
                              PRIMARY KEY (user_id, group_id),
                              FOREIGN KEY (user_id) REFERENCES users(id),
                              FOREIGN KEY (group_id) REFERENCES groups(id)
@@ -68,10 +69,10 @@ INSERT INTO users (id, username, email, password) VALUES
 
 
 -- Groups
-INSERT INTO groups (id, name, description) VALUES
-                                              (1, 'ICT23-SW', 'Notes for SEP1 class.'),
-                                              (2, 'IT Team', 'Work-related discussions and updates.'),
-                                              (3, 'Teacher Group', 'Discussion group for teachers.');
+INSERT INTO groups (id, name, description, user_id) VALUES
+                                              (1, 'ICT23-SW', 'Notes for SEP1 class.', 1),
+                                              (2, 'IT Team', 'Work-related discussions and updates.', 2),
+                                              (3, 'Teacher Group', 'Discussion group for teachers.', 3);
 
 -- Notes
 INSERT INTO notes (id, title, text, colour, created_at, updated_at, user_id, group_id) VALUES
@@ -82,11 +83,11 @@ INSERT INTO notes (id, title, text, colour, created_at, updated_at, user_id, gro
 
 
 -- Is Part Of (User-Group Relationship)
-INSERT INTO user_groups (user_id, group_id, is_owner) VALUES
-                                             (1, 1, true),
-                                             (1, 2, false),
-                                             (2, 3, false),
-                                             (3, 1, false);
+INSERT INTO user_groups (user_id, group_id) VALUES
+                                             (1, 1),
+                                             (1, 2),
+                                             (2, 3),
+                                             (3, 1);
 
 -- Figures
 INSERT INTO figures (id, link, note_id) VALUES

--- a/src/test/java/org/metropolia/minimalnotepad/service/UserGroupParticipationServiceTest.java
+++ b/src/test/java/org/metropolia/minimalnotepad/service/UserGroupParticipationServiceTest.java
@@ -1,0 +1,150 @@
+package org.metropolia.minimalnotepad.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.metropolia.minimalnotepad.model.Group;
+import org.metropolia.minimalnotepad.model.User;
+import org.metropolia.minimalnotepad.model.UserGroupParticipation;
+import org.metropolia.minimalnotepad.repository.GroupRepository;
+import org.metropolia.minimalnotepad.repository.UserGroupParticipationRepository;
+import org.metropolia.minimalnotepad.repository.UserRepository;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserGroupParticipationServiceTest {
+
+    @Mock
+    private UserGroupParticipationRepository userGroupParticipationRepository;
+
+    @Mock
+    private GroupRepository groupRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserGroupParticipationService userGroupParticipationService;
+
+    private User testUser;
+    private Group testGroup;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        testUser = new User();
+        testUser.setId(1L);
+        testGroup = new Group();
+        testGroup.setId(1L);
+    }
+
+    @Test
+    void testJoinGroup() {
+        when(userRepository.findById(testUser.getId())).thenReturn(java.util.Optional.of(testUser));
+        when(groupRepository.findById(testGroup.getId())).thenReturn(java.util.Optional.of(testGroup));
+        when(userGroupParticipationRepository.findByUserAndGroup(testUser, testGroup)).thenReturn(java.util.Optional.empty());
+
+        UserGroupParticipation participation = new UserGroupParticipation();
+        participation.setUser(testUser);
+        participation.setGroup(testGroup);
+
+        when(userGroupParticipationRepository.save(any(UserGroupParticipation.class))).thenReturn(participation);
+
+        UserGroupParticipation result = userGroupParticipationService.joinGroup(testUser.getId(), testGroup.getId());
+
+        assertNotNull(result);
+        assertEquals(testUser, result.getUser());
+        assertEquals(testGroup, result.getGroup());
+
+        verify(userGroupParticipationRepository, times(1)).save(any(UserGroupParticipation.class));
+    }
+
+    @Test
+    void testJoinGroup_UserAlreadyMember() {
+        when(userRepository.findById(testUser.getId())).thenReturn(java.util.Optional.of(testUser));
+        when(groupRepository.findById(testGroup.getId())).thenReturn(java.util.Optional.of(testGroup));
+        when(userGroupParticipationRepository.findByUserAndGroup(testUser, testGroup)).thenReturn(java.util.Optional.of(new UserGroupParticipation()));
+
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            userGroupParticipationService.joinGroup(testUser.getId(), testGroup.getId());
+        });
+
+        assertEquals("User is already a member of this group.", exception.getMessage());
+    }
+
+    @Test
+    void testJoinGroup_UserNotFound() {
+        when(userRepository.findById(testUser.getId())).thenReturn(java.util.Optional.empty());
+
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            userGroupParticipationService.joinGroup(testUser.getId(), testGroup.getId());
+        });
+
+        assertEquals("User not found", exception.getMessage());
+    }
+
+    @Test
+    void testJoinGroup_GroupNotFound() {
+        when(userRepository.findById(testUser.getId())).thenReturn(java.util.Optional.of(testUser));
+        when(groupRepository.findById(testGroup.getId())).thenReturn(java.util.Optional.empty());
+
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            userGroupParticipationService.joinGroup(testUser.getId(), testGroup.getId());
+        });
+
+        assertEquals("Group not found", exception.getMessage());
+    }
+
+    @Test
+    void testLeaveGroup() {
+        UserGroupParticipation participation = new UserGroupParticipation();
+        participation.setUser(testUser);
+        participation.setGroup(testGroup);
+
+        when(userRepository.findById(testUser.getId())).thenReturn(java.util.Optional.of(testUser));
+        when(groupRepository.findById(testGroup.getId())).thenReturn(java.util.Optional.of(testGroup));
+        when(userGroupParticipationRepository.findByUserAndGroup(testUser, testGroup)).thenReturn(java.util.Optional.of(participation));
+
+        userGroupParticipationService.leaveGroup(testUser.getId(), testGroup.getId());
+
+        verify(userGroupParticipationRepository, times(1)).delete(participation);
+    }
+
+    @Test
+    void testLeaveGroup_UserNotFound() {
+        when(userRepository.findById(testUser.getId())).thenReturn(java.util.Optional.empty());
+
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            userGroupParticipationService.leaveGroup(testUser.getId(), testGroup.getId());
+        });
+
+        assertEquals("User not found", exception.getMessage());
+    }
+
+    @Test
+    void testLeaveGroup_GroupNotFound() {
+        when(userRepository.findById(testUser.getId())).thenReturn(java.util.Optional.of(testUser));
+        when(groupRepository.findById(testGroup.getId())).thenReturn(java.util.Optional.empty());
+
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            userGroupParticipationService.leaveGroup(testUser.getId(), testGroup.getId());
+        });
+
+        assertEquals("Group not found", exception.getMessage());
+    }
+
+    @Test
+    void testLeaveGroup_MembershipNotFound() {
+        when(userRepository.findById(testUser.getId())).thenReturn(java.util.Optional.of(testUser));
+        when(groupRepository.findById(testGroup.getId())).thenReturn(java.util.Optional.of(testGroup));
+        when(userGroupParticipationRepository.findByUserAndGroup(testUser, testGroup)).thenReturn(java.util.Optional.empty());
+
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            userGroupParticipationService.leaveGroup(testUser.getId(), testGroup.getId());
+        });
+
+        assertEquals("User is not a member of this group.", exception.getMessage());
+    }
+}

--- a/src/test/java/org/metropolia/minimalnotepad/service/UserServiceTest.java
+++ b/src/test/java/org/metropolia/minimalnotepad/service/UserServiceTest.java
@@ -7,6 +7,7 @@ import org.metropolia.minimalnotepad.exception.UserAlreadyExistsException;
 import org.metropolia.minimalnotepad.exception.UserNotFoundException;
 import org.metropolia.minimalnotepad.model.User;
 import org.metropolia.minimalnotepad.repository.UserRepository;
+import org.metropolia.minimalnotepad.utils.JwtUtils;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -28,12 +29,15 @@ public class UserServiceTest {
     @Mock
     private PasswordEncoder passwordEncoder;
 
+    @Mock
+    private JwtUtils jwtUtils;
+
     @InjectMocks
     private UserService userService;
 
     @BeforeEach
     void setUp() {
-        userService = new UserService(userRepository, passwordEncoder);
+        userService = new UserService(userRepository, passwordEncoder, jwtUtils);
     }
 
     @Test


### PR DESCRIPTION
1. Moved group owner into group (database + model) (now when a user deletes their account, the system deletes the user's own groups and participations automatically), made group name unique
2. Added group operations:
- get groups by user id (by owner)
- join group
- leave group
3. Added tests for services and controllers for those operations
4. Added postman requests for those operations