### PR TITLE
Error messages localization

### DIFF
--- a/src/main/java/org/metropolia/minimalnotepad/config/MessageSourceConfig.java
+++ b/src/main/java/org/metropolia/minimalnotepad/config/MessageSourceConfig.java
@@ -1,0 +1,27 @@
+package org.metropolia.minimalnotepad.config;
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ResourceBundleMessageSource;
+import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
+
+import java.util.Locale;
+
+@Configuration
+public class MessageSourceConfig {
+    @Bean
+    public LocaleResolver localeResolver() {
+        AcceptHeaderLocaleResolver locale = new AcceptHeaderLocaleResolver();
+        locale.setDefaultLocale(Locale.ENGLISH);
+        return locale;
+    }
+
+    @Bean("messageSource")
+    public MessageSource messageSource() {
+        ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
+        messageSource.setBasename("i18n/messages");
+        messageSource.setDefaultEncoding("UTF-8");
+        return messageSource;
+    }
+}

--- a/src/main/java/org/metropolia/minimalnotepad/controller/AuthenticationController.java
+++ b/src/main/java/org/metropolia/minimalnotepad/controller/AuthenticationController.java
@@ -4,39 +4,47 @@ import org.metropolia.minimalnotepad.dto.AuthenticationResponse;
 import org.metropolia.minimalnotepad.dto.ErrorResponse;
 import org.metropolia.minimalnotepad.dto.LoginRequest;
 import org.metropolia.minimalnotepad.dto.RegisterRequest;
+import org.metropolia.minimalnotepad.dto.LoginResponse;
 import org.metropolia.minimalnotepad.model.User;
 import org.metropolia.minimalnotepad.service.AuthenticationService;
+import org.metropolia.minimalnotepad.service.MessageService;
 import org.metropolia.minimalnotepad.service.UserService;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Locale;
 
 @RestController
 @RequestMapping("/api/users-authentication")
 public class AuthenticationController {
     private final UserService userService;
     private final AuthenticationService authenticationService;
+    private final MessageService messageService;
 
-    public AuthenticationController(UserService userService, AuthenticationService authenticationService) {
+    public AuthenticationController(UserService userService, AuthenticationService authenticationService, MessageService messageService) {
         this.userService = userService;
         this.authenticationService = authenticationService;
+        this.messageService = messageService;
     }
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody LoginRequest loginRequest) {
-        try
-        {
-            String jwt = authenticationService.authenticate(loginRequest.getUsername(), loginRequest.getPassword());
-            return ResponseEntity.ok(new AuthenticationResponse(jwt, loginRequest.getUsername()));
-        }catch (Exception e)
-        {
-            if(e instanceof UsernameNotFoundException)
-            {
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponse(404, e.getMessage()));
+    public ResponseEntity<?> login(@RequestBody LoginRequest loginRequest,
+                                   @RequestHeader(name = "Accept-Language", required = false) Locale locale) {
+        try {
+            String jwt = authenticationService.authenticate(loginRequest.getUsername(), loginRequest.getPassword(), locale);
+            User user = userService.getUserByUsername(loginRequest.getUsername());
+            String language = user.getLanguage().getName();
+            return ResponseEntity.ok(new LoginResponse(jwt, loginRequest.getUsername(), language));
+        } catch (Exception e) {
+            if (e instanceof UsernameNotFoundException) {
+                String message = messageService.get("error.login.usernameNotFound", locale);
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponse(404, message));
             }
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponse(401, e.getMessage()));
+
+            String message = messageService.get("error.login.failed", locale);
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponse(401, message));
         }
     }
 
@@ -45,7 +53,8 @@ public class AuthenticationController {
         try
         {
             User registeredUser = userService.registerUser(registerRequest.getUsername(),registerRequest.getEmail(),registerRequest.getPassword(),registerRequest.getLanguage());
-            String jwt = authenticationService.authenticate(registeredUser.getUsername(),registerRequest.getPassword());
+            Locale locale = new Locale(registerRequest.getLanguage());
+            String jwt = authenticationService.authenticate(registeredUser.getUsername(),registerRequest.getPassword(),locale);
             return ResponseEntity.ok(new AuthenticationResponse(jwt, registerRequest.getUsername()));
         }catch (Exception e)
         {

--- a/src/main/java/org/metropolia/minimalnotepad/dto/LoginResponse.java
+++ b/src/main/java/org/metropolia/minimalnotepad/dto/LoginResponse.java
@@ -1,0 +1,19 @@
+package org.metropolia.minimalnotepad.dto;
+
+public class LoginResponse {
+    private String token;
+    private String username;
+    private String languageCode;
+    public LoginResponse(String token, String username, String languageCode) {
+        this.token = token;
+        this.username = username;
+        this.languageCode = languageCode;
+    }
+    public String getToken() {
+        return token;
+    }
+    public String getUsername() {
+        return username;
+    }
+    public String getLanguageCode() { return languageCode; }
+}

--- a/src/main/java/org/metropolia/minimalnotepad/service/AuthenticationService.java
+++ b/src/main/java/org/metropolia/minimalnotepad/service/AuthenticationService.java
@@ -9,26 +9,32 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.Locale;
+
 @Service
 public class AuthenticationService {
     private UserRepository userRepository;
     private JwtUtils jwtUtils;
     private PasswordEncoder passwordEncoder;
-    public AuthenticationService(UserRepository userRepository, JwtUtils jwtUtils, PasswordEncoder passwordEncoder)
+    private MessageService messageService;
+    public AuthenticationService(UserRepository userRepository, JwtUtils jwtUtils, PasswordEncoder passwordEncoder, MessageService messageService)
     {
         this.userRepository = userRepository;
         this.jwtUtils = jwtUtils;
         this.passwordEncoder = passwordEncoder;
+        this.messageService = messageService;
     }
 
-    public String authenticate(String username, String password) {
+    public String authenticate(String username, String password, Locale locale) {
         User findUser = userRepository.findUserByUsername(username);
         if (findUser == null) {
-            throw new UsernameNotFoundException("User not found");
+            String message = messageService.get("error.login.usernameNotFound", locale);
+            throw new UsernameNotFoundException(message);
         }
         if (!passwordEncoder.matches(password, findUser.getPassword()))
         {
-            throw new BadCredentialsException("Bad credentials");
+            String message = messageService.get("error.login.failed", locale);
+            throw new BadCredentialsException(message);
         }
         return jwtUtils.generateToken(username);
     }

--- a/src/main/java/org/metropolia/minimalnotepad/service/MessageService.java
+++ b/src/main/java/org/metropolia/minimalnotepad/service/MessageService.java
@@ -1,0 +1,27 @@
+package org.metropolia.minimalnotepad.service;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Service;
+
+import java.util.Locale;
+
+@Service
+public class MessageService {
+
+    private final MessageSource messageSource;
+
+    public MessageService(MessageSource messageSource) {
+        this.messageSource = messageSource;
+    }
+
+    public String get(String key, Object[] args, Locale locale) {
+        return messageSource.getMessage(key, args, locale);
+    }
+
+    public String get(String key, Locale locale) {
+        return get(key, null, locale);
+    }
+
+    public String get(String key) {
+        return get(key, null, Locale.getDefault());
+    }
+}

--- a/src/main/resources/POSTMAN/Minimal Notepad.postman_collection.json
+++ b/src/main/resources/POSTMAN/Minimal Notepad.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "566da1d7-063f-4155-897d-1eb3ad923f6d",
+		"_postman_id": "9b47b608-4e1a-4ef8-a3d3-5ba6ac307c62",
 		"name": "Minimal Notepad",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "29851757"
@@ -16,10 +16,16 @@
 							"type": "noauth"
 						},
 						"method": "POST",
-						"header": [],
+						"header": [
+							{
+								"key": "Accept-Language",
+								"value": "fi",
+								"type": "text"
+							}
+						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"username\": \"test\",\r\n    \"password\":\"test\"\r\n}",
+							"raw": "{\r\n    \"username\": \"test16\",\r\n    \"password\":\"test\"\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/src/main/resources/POSTMAN/Minimal Notepad.postman_collection.json
+++ b/src/main/resources/POSTMAN/Minimal Notepad.postman_collection.json
@@ -25,7 +25,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"username\": \"test16\",\r\n    \"password\":\"test\"\r\n}",
+							"raw": "{\r\n    \"username\": \"test\",\r\n    \"password\":\"test\"\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -1,0 +1,4 @@
+error.login.usernameNotFound=Username not found
+error.login.failed=Invalid username or password
+error.register.emailExists=Email already exists.
+error.register.usernameExists=Username already exists.

--- a/src/main/resources/i18n/messages_fi.properties
+++ b/src/main/resources/i18n/messages_fi.properties
@@ -1,0 +1,4 @@
+error.login.usernameNotFound=Käyttäjätunnusta ei löydy
+error.login.failed=Virheellinen kirjautuminen tai salasana
+error.register.emailExists=Sähköposti on jo käytössä.
+error.register.usernameExists=Käyttäjätunnus on jo käytössä.

--- a/src/main/resources/i18n/messages_ru.properties
+++ b/src/main/resources/i18n/messages_ru.properties
@@ -1,0 +1,4 @@
+error.login.usernameNotFound=Имя пользователя не найдено
+error.login.failed=Неверное имя пользователя или пароль
+error.register.emailExists=Электронная почта уже используется.
+error.register.usernameExists=Имя пользователя уже существует.

--- a/src/main/resources/i18n/messages_zh.properties
+++ b/src/main/resources/i18n/messages_zh.properties
@@ -1,0 +1,4 @@
+error.login.usernameNotFound=用户名未找到
+error.login.failed=登录失败或密码错误
+error.register.emailExists=电子邮件已存在。
+error.register.usernameExists=用户名已存在。

--- a/src/test/java/org/metropolia/minimalnotepad/controller/AuthenticationControllerTest.java
+++ b/src/test/java/org/metropolia/minimalnotepad/controller/AuthenticationControllerTest.java
@@ -5,9 +5,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.metropolia.minimalnotepad.dto.AuthenticationResponse;
-import org.metropolia.minimalnotepad.dto.LoginRequest;
-import org.metropolia.minimalnotepad.dto.RegisterRequest;
+import org.metropolia.minimalnotepad.dto.*;
 import org.metropolia.minimalnotepad.model.Language;
 import org.metropolia.minimalnotepad.model.User;
 import org.metropolia.minimalnotepad.repository.LanguageRepository;
@@ -19,6 +17,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -66,14 +66,17 @@ public class AuthenticationControllerTest {
         userMock.setUsername("username");
         userMock.setPassword(passwordEncoder.encode("password"));
         userMock.setEmail("email@email.com");
+        userMock.setLanguage(languageRepository.findByName("en").orElse(null));
 
         userRepository.save(userMock);
 
-        ResponseEntity<?> responseEntity = authenticationController.login(new LoginRequest(userMock.getUsername(), "password"));
+        Locale locale = Locale.forLanguageTag("en");
+
+        ResponseEntity<?> responseEntity = authenticationController.login(new LoginRequest(userMock.getUsername(), "password"), locale);
 
         assertNotNull(responseEntity);
         assertEquals(200,responseEntity.getStatusCode().value());
-        AuthenticationResponse authenticationResponse = (AuthenticationResponse) responseEntity.getBody();
+        LoginResponse authenticationResponse = (LoginResponse) responseEntity.getBody();
         assertEquals("username", authenticationResponse.getUsername());
         assertEquals(jwtUtils.generateToken(userMock.getUsername()), authenticationResponse.getToken());
     }
@@ -87,7 +90,9 @@ public class AuthenticationControllerTest {
 
         userRepository.save(userMock);
 
-        ResponseEntity<?> responseEntity = authenticationController.login(new LoginRequest(userMock.getUsername(), "badPassword"));
+        Locale locale = Locale.forLanguageTag("en");
+
+        ResponseEntity<?> responseEntity = authenticationController.login(new LoginRequest(userMock.getUsername(), "badPassword"), locale);
         assertNotNull(responseEntity);
         assertEquals(401,responseEntity.getStatusCode().value());
 
@@ -95,7 +100,8 @@ public class AuthenticationControllerTest {
     @Test
     public void testLoginInvalidUser()
     {
-        ResponseEntity<?> responseEntity = authenticationController.login(new LoginRequest("username", "badPassword"));
+        Locale locale = Locale.forLanguageTag("en");
+        ResponseEntity<?> responseEntity = authenticationController.login(new LoginRequest("username", "badPassword"), locale);
 
         assertNotNull(responseEntity);
         assertEquals(404,responseEntity.getStatusCode().value());

--- a/src/test/java/org/metropolia/minimalnotepad/service/AuthenticationServiceTest.java
+++ b/src/test/java/org/metropolia/minimalnotepad/service/AuthenticationServiceTest.java
@@ -12,6 +12,8 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.Locale;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,6 +33,9 @@ public class AuthenticationServiceTest {
     @InjectMocks
     private AuthenticationService authService;
 
+    @Mock
+    private MessageService messageService;
+
     @Test
     public void testAuthenticateValidAttempt()
     {
@@ -42,7 +47,7 @@ public class AuthenticationServiceTest {
         when(passwordEncoder.matches("password123","encodedPassword123")).thenReturn(true);
         when(jwtUtils.generateToken(mockUser.getUsername())).thenReturn("mockToken");
 
-        String token = authService.authenticate("testuser", "password123");
+        String token = authService.authenticate("testuser", "password123", Locale.getDefault());
 
         assertNotNull(token);
         assertEquals("mockToken", token);
@@ -57,6 +62,6 @@ public class AuthenticationServiceTest {
         mockUser.setUsername("testuser");
         mockUser.setPassword("encodedPassword123");
         when(userRepository.findUserByUsername("testuser")).thenReturn(null);
-        assertThrows(UsernameNotFoundException.class, () -> authService.authenticate("testuser", "password123"));
+        assertThrows(UsernameNotFoundException.class, () -> authService.authenticate("testuser", "password123", Locale.getDefault()));
     }
 }

--- a/src/test/java/org/metropolia/minimalnotepad/service/UserServiceTest.java
+++ b/src/test/java/org/metropolia/minimalnotepad/service/UserServiceTest.java
@@ -41,11 +41,14 @@ public class UserServiceTest {
     @InjectMocks
     private UserService userService;
 
+    @Mock
+    private MessageService messageService;
+
     Language language = new Language();
 
     @BeforeEach
     void setUp() {
-        userService = new UserService(userRepository, passwordEncoder, jwtUtils, languageRepository);
+        userService = new UserService(userRepository, passwordEncoder, jwtUtils, languageRepository, messageService);
 
         // Set up a mock Language object
         language.setName("en");


### PR DESCRIPTION
1. Added LanguageCode in Login responce
2. Added error message localization (_only for login and registration_, as we dealt today I won't continue with other error messages localization)
3. Fixed tests for these new features, updated postman